### PR TITLE
Avoid extra memory copy in ndarray to vlen conversion

### DIFF
--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -31,7 +31,9 @@ cnp._import_array()
 
 import numpy as np
 
-from cpython.buffer cimport PyObject_GetBuffer, PyBuffer_ToContiguous, PyBuffer_Release, PyBUF_SIMPLE, PyBUF_INDIRECT
+from cpython.buffer cimport (
+    PyObject_GetBuffer, PyBuffer_ToContiguous, PyBuffer_Release, PyBUF_INDIRECT
+)
 from cpython.object cimport PyObject
 from cpython.ref cimport Py_INCREF, Py_XDECREF, Py_XINCREF
 

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -31,6 +31,7 @@ cnp._import_array()
 
 import numpy as np
 
+from cpython.buffer cimport PyObject_GetBuffer, PyBuffer_ToContiguous, PyBuffer_Release, PyBUF_SIMPLE, PyBUF_INDIRECT
 from cpython.object cimport PyObject
 from cpython.ref cimport Py_INCREF, Py_XDECREF, Py_XINCREF
 
@@ -814,15 +815,19 @@ cdef int conv_ndarray2vlen(void* ipt,
         cnp.ndarray ndarray
         size_t len, nbytes
         PyObject* buf_obj0
+        Py_buffer view
 
     buf_obj0 = buf_obj[0]
-    ndarray = np.ascontiguousarray(<cnp.ndarray> buf_obj0)
+    ndarray = <cnp.ndarray> buf_obj0
     len = ndarray.shape[0]
     nbytes = len * max(outtype.get_size(), intype.get_size())
 
     data = emalloc(nbytes)
 
-    memcpy(data, ndarray.data, intype.get_size() * len)
+    PyObject_GetBuffer(ndarray, &view, PyBUF_INDIRECT)
+    PyBuffer_ToContiguous(data, &view, view.len, b'C')
+    PyBuffer_Release(&view)
+
     H5Tconvert(intype.id, outtype.id, len, data, NULL, H5P_DEFAULT)
 
     in_vlen[0].len = len

--- a/h5py/_conv.pyx
+++ b/h5py/_conv.pyx
@@ -29,8 +29,6 @@ cimport numpy as cnp
 from numpy cimport npy_intp, NPY_WRITEABLE, NPY_C_CONTIGUOUS, NPY_OWNDATA
 cnp._import_array()
 
-import numpy as np
-
 from cpython.buffer cimport (
     PyObject_GetBuffer, PyBuffer_ToContiguous, PyBuffer_Release, PyBUF_INDIRECT
 )


### PR DESCRIPTION
The test you added passes for me, at least. Please do check if this makes sense - I'm not very familiar with the Python buffer API, so I might be misunderstanding it.